### PR TITLE
Fix bug where DC motors would not be stopped

### DIFF
--- a/sys/AFC/Motors/dc_motors.g
+++ b/sys/AFC/Motors/dc_motors.g
@@ -23,17 +23,23 @@ if param.A = "F"
     M950 P1 C{var.DC1_pin}
     M950 P2 C{var.DC2_pin}
     M42 P0 S1
+    M42 P1 S0
     M42 P2 S1
-
+    
 if param.A = "R"
     M950 P0 C{var.SLP_pin}
     M950 P1 C{var.DC1_pin}
     M950 P2 C{var.DC2_pin}
     M42 P0 S1
     M42 P1 S1
-
+    M42 P2 S0
+    
 if param.A = "O"
+    M950 P0 C{var.SLP_pin}
+    M950 P1 C{var.DC1_pin}
+    M950 P2 C{var.DC2_pin}
     M42 P0 S0
+    M42 P1 S0
     M42 P2 S0
     M950 P0 C"nil"
     M950 P1 C"nil"


### PR DESCRIPTION
 Pins are unassigned every time the script runs so previously no pin was configured to be able to turn off the motor.

This change also consistently configures and sets all three motor control pins to the required states for all operations.